### PR TITLE
Allow sending files to the root of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Glob or array of globs to read.
 Type: `string`<br>
 **Required**
 
-Relative destination path.
+Relative destination path. Empty string (`''`) denotes the root of the repository.
 
 ### remote
 


### PR DESCRIPTION
Hi, I came across this module a couple of weeks ago, and it does almost everything I need.
This PR adds the ability to send files to the root of a remote repository by setting `destination` to `''`.

For safety we could enable this via an option.
I was going to write some tests, but I can't get them to run locally.
